### PR TITLE
Added the ability to control the color of the plots

### DIFF
--- a/R/plot.BEST.R
+++ b/R/plot.BEST.R
@@ -1,6 +1,8 @@
 plot.BEST <-
 function(x, which=c("mean", "sd", "effect", "nu"), credMass=0.95,
-                    ROPE=NULL, compVal=0, showCurve=FALSE, ...) {
+                    ROPE=NULL, compVal=0, showCurve=FALSE,  
+                    mainColor="skyblue", dataColor="red", comparisonColor="darkgreen", ROPEColor = "darkred",
+                    ...) {
   # This function plots the posterior distribution for one selected item. 
   # Description of arguments:
   # x is mcmc.list object of the type returned by function BESTmcmc.
@@ -61,7 +63,8 @@ function(x, which=c("mean", "sd", "effect", "nu"), credMass=0.95,
   # Plot posterior distribution of selected item:
   histinfo <- plotPost(toPlot, credMass=credMass, ROPE=ROPE, showCurve=showCurve,
                   showMode=whichID != "mean",
-                  compVal=compVal, graphPars=dots) 
+                  compVal=compVal, graphPars=dots,
+                  mainColor = mainColor, comparisonColor = comparisonColor, ROPEColor = ROPEColor) 
 
   return(invisible(histinfo))
 }

--- a/R/plotAll.R
+++ b/R/plotAll.R
@@ -4,7 +4,9 @@ plotAll <-
 function(BESTobj, credMass=0.95,
                     ROPEm=NULL, ROPEsd=NULL, ROPEeff=NULL,
                     compValm=0, compValsd=NULL, compValeff=0,
-                    showCurve=FALSE, ...) {
+                    showCurve=FALSE, 
+                    mainColor="skyblue", dataColor="red", comparisonColor="darkgreen", ROPEColor = "darkred", 
+                    ...) {
   # This function plots the posterior distribution (and data). It does not
   #   produce a scatterplot matrix; use pairs(...) for that.
   # Description of arguments:
@@ -51,12 +53,14 @@ function(BESTobj, credMass=0.95,
   stepIdxVec <- seq(1, chainLength, length.out=nCurvesToPlot)
   toPlot <- BESTobj[stepIdxVec, ]
 
-  plotDataPPC(toPlot=toPlot, oneGrp=oneGrp, data=data)
+  plotDataPPC(toPlot=toPlot, oneGrp=oneGrp, data=data, lineColor = mainColor, dataColor=dataColor)
 
   # Plot posterior distributions and their differences
   # --------------------------------------------------
   # Plot posterior distribution of parameter nu:
-  plotPost( log10(BESTobj$nu) , col="skyblue" ,  credMass=credMass,
+  plotPost( log10(BESTobj$nu) , 
+            mainColor = mainColor, comparisonColor = comparisonColor, ROPEColor = ROPEColor,
+            credMass=credMass,
                        showCurve=showCurve ,
                   xlab=bquote("log10("*nu*")") , cex.lab = 1.75 , showMode=TRUE ,
                   main="Normality" ) #  (<0.7 suggests kurtosis)
@@ -67,19 +71,20 @@ function(BESTobj, credMass=0.95,
     plotPost( BESTobj$mu1 ,  xlim=xlim , cex.lab = 1.75 , credMass=credMass,
                        showCurve=showCurve , ROPE=ROPEm, compVal=compValm,
                   xlab=bquote(mu) , main="Mean" , 
-                  col="skyblue" )
+                  mainColor = mainColor, comparisonColor = comparisonColor, ROPEColor = ROPEColor)
   } else {
     plotPost( BESTobj$mu1 ,  xlim=xlim , cex.lab = 1.75 , credMass=credMass,
                        showCurve=showCurve ,
                   xlab=bquote(mu[1]) , main=paste("Group",1,"Mean") , 
-                  col="skyblue" )
+                  mainColor = mainColor, comparisonColor = comparisonColor, ROPEColor = ROPEColor)
     plotPost( BESTobj$mu2 ,  xlim=xlim , cex.lab = 1.75 , credMass=credMass,
                          showCurve=showCurve ,
                     xlab=bquote(mu[2]) , main=paste("Group",2,"Mean") , 
-                    col="skyblue" )
+                    mainColor = mainColor, comparisonColor = comparisonColor, ROPEColor = ROPEColor)
     plotPost( BESTobj$mu1-BESTobj$mu2 , compVal=0 ,  showCurve=showCurve , credMass=credMass,
                     xlab=bquote(mu[1] - mu[2]) , cex.lab = 1.75 , ROPE=ROPEm ,
-                    main="Difference of Means" , col="skyblue" )
+                    main="Difference of Means" , 
+                    mainColor = mainColor, comparisonColor = comparisonColor, ROPEColor = ROPEColor)
   }
 
   # Plot posterior distribution of param's sigma1, sigma2, and their difference:
@@ -88,21 +93,26 @@ function(BESTobj, credMass=0.95,
     plotPost(BESTobj$sigma1, xlim=xlim, cex.lab = 1.75, credMass=credMass,
                        showCurve=showCurve, ROPE=ROPEsd, compVal=compValsd,
                   xlab=bquote(sigma) , main="Std. Dev." , 
-                  col="skyblue" , showMode=TRUE )
+                  mainColor = mainColor, comparisonColor = comparisonColor, ROPEColor = ROPEColor,
+                  showMode=TRUE )
   } else {
     plotPost( BESTobj$sigma1 ,  xlim=xlim , cex.lab = 1.75 , credMass=credMass,
                        showCurve=showCurve ,
                   xlab=bquote(sigma[1]) , main=paste("Group",1,"Std. Dev.") , 
-                  col="skyblue" , showMode=TRUE )
+                  mainColor = mainColor, comparisonColor = comparisonColor, ROPEColor = ROPEColor,
+                  showMode=TRUE )
     plotPost( BESTobj$sigma2 ,  xlim=xlim , cex.lab = 1.75 , credMass=credMass,
                          showCurve=showCurve ,
                     xlab=bquote(sigma[2]) , main=paste("Group",2,"Std. Dev.") , 
-                    col="skyblue" , showMode=TRUE )
+                    mainColor = mainColor, comparisonColor = comparisonColor, ROPEColor = ROPEColor, 
+                    showMode=TRUE )
     plotPost( BESTobj$sigma1-BESTobj$sigma2 ,  credMass=credMass,
                          compVal=compValsd ,  showCurve=showCurve ,
                          xlab=bquote(sigma[1] - sigma[2]) , cex.lab = 1.75 , 
                          ROPE=ROPEsd ,
-                 main="Difference of Std. Dev.s" , col="skyblue" , showMode=TRUE )
+                 main="Difference of Std. Dev.s" , 
+                 mainColor = mainColor, comparisonColor = comparisonColor, ROPEColor = ROPEColor,
+                 showMode=TRUE )
   }
 
   # Plot effect size
@@ -113,7 +123,8 @@ function(BESTobj, credMass=0.95,
   plotPost( effectSize , compVal=compValeff ,  ROPE=ROPEeff , credMass=credMass,
                  showCurve=showCurve ,
                  xlab=bquote( (mu-.(compValm)) / sigma ),
-                 showMode=TRUE , cex.lab=1.75 , main="Effect Size" , col="skyblue" )
+                 showMode=TRUE , cex.lab=1.75 , main="Effect Size" , 
+                 mainColor = mainColor, comparisonColor = comparisonColor, ROPEColor = ROPEColor)
   } else {
     # Plot of estimated effect size. Effect size is d-sub-a from 
     # Macmillan & Creelman, 1991; Simpson & Fitter, 1973; Swets, 1986a, 1986b.
@@ -122,7 +133,8 @@ function(BESTobj, credMass=0.95,
                           showCurve=showCurve ,
                     xlab=bquote( (mu[1]-mu[2])
                       /sqrt((sigma[1]^2 +sigma[2]^2 )/2 ) ),
-                showMode=TRUE , cex.lab=1.0 , main="Effect Size" , col="skyblue" )
+                showMode=TRUE , cex.lab=1.0 , main="Effect Size" ,
+                mainColor = mainColor, comparisonColor = comparisonColor, ROPEColor = ROPEColor)
   }
   # Or use sample-size weighted version:
   # Hedges 1981; Wetzels, Raaijmakers, Jakab & Wagenmakers 2009.
@@ -135,6 +147,6 @@ function(BESTobj, credMass=0.95,
   #          showCurve=showCurve ,
   #          xlab=bquote( (mu[1]-mu[2])
   #          /sqrt((sigma[1]^2 *(N[1]-1)+sigma[2]^2 *(N[2]-1))/(N[1]+N[2]-2)) ),
-  #          showMode=TRUE , cex.lab=1.0 , main="Effect Size" , col="skyblue" )
+  #          showMode=TRUE , cex.lab=1.0 , main="Effect Size" , col=mainColor )
   return(invisible(NULL))
 }

--- a/R/plotAreaInROPE.R
+++ b/R/plotAreaInROPE.R
@@ -1,6 +1,7 @@
 plotAreaInROPE <- 
 function(paramSampleVec, credMass = 0.95, compVal = 0, maxROPEradius,
-  n = 201, plot = TRUE,...) {
+  n = 201, plot = TRUE,
+  ROPEColor = "darkred", ...) {
   # Plots the probability mass included in the ROPE as a function of
   #   the half-width of the ROPE.
 
@@ -25,7 +26,7 @@ function(paramSampleVec, credMass = 0.95, compVal = 0, maxROPEradius,
     if(length(dots) == 1 && class(dots[[1]]) == "list")
       dots <- dots[[1]]
     defaultArgs <- list(xlab=bquote("Radius of ROPE around "*.(compVal)),
-      ylab="Posterior in ROPE", type="l", lwd=4, col="darkred", cex.lab=1.5) 
+      ylab="Posterior in ROPE", type="l", lwd=4, col=ROPEColor, cex.lab=1.5) 
     useArgs <- modifyList(defaultArgs, dots)
     useArgs$x <- ropeRadVec
     useArgs$y <- areaInRope
@@ -36,12 +37,12 @@ function(paramSampleVec, credMass = 0.95, compVal = 0, maxROPEradius,
     areaInFarHDIlim <- mean( paramSampleVec > (compVal-ropeRadHDI)
                            & paramSampleVec < (compVal+ropeRadHDI) )
     lines( c(ropeRadHDI, ropeRadHDI) , c(-0.5, areaInFarHDIlim) ,
-           lty="dashed" , col="darkred" )
+           lty="dashed" , col=ROPEColor )
     text( ropeRadHDI , 0 ,
           bquote( atop( .(100*credMass)*"% HDI limit" ,
                        "farthest from "*.(compVal) ) ) , adj=c(0.5,0) )
     lines( c(-0.5, ropeRadHDI) ,c(areaInFarHDIlim, areaInFarHDIlim) ,
-           lty="dashed" , col="darkred" )
+           lty="dashed" , col=ROPEColor )
     text( 0 , areaInFarHDIlim , bquote(.(signif(areaInFarHDIlim, 3))) ,
           adj=c(0, 1.1) )
   }

--- a/R/plotDataPPC.R
+++ b/R/plotDataPPC.R
@@ -2,7 +2,8 @@
 #  with same xlim and ylim parameters.
 
 plotDataPPC <-
-function(toPlot, oneGrp, data) {
+function(toPlot, oneGrp, data, 
+         lineColor= 'skyblue', dataColor='red') {
   # Does the plots of posterior predictive curves for one OR TWO samples
   # Called by plotAll and plotPostPred; no sanity checks; not exported.
   # Calling function should arrange for multiple plots with par(mfrow) or layout.
@@ -54,11 +55,11 @@ function(toPlot, oneGrp, data) {
     if(!is.null(data$y1))
       text( max(xVec) , maxY , bquote(N[1]==.(length(data$y1))) , adj=c(1.1,1.1) )
   }
-  matlines(x=xVec, y=PPDmat[, , 1], lty=1, col="skyblue")
+  matlines(x=xVec, y=PPDmat[, , 1], lty=1, col=lineColor)
   if(!is.null(hist1)) {
     op <- par(lwd=2)
-    plot(hist1, freq=FALSE, border='red', add=TRUE)
-    segments(x0=xVec[1], y0=0, x1=xVec[npoints], col='red')
+    plot(hist1, freq=FALSE, border=dataColor, add=TRUE)
+    segments(x0=xVec[1], y0=0, x1=xVec[npoints], col=dataColor)
     par(op)
   }
   # Maybe do second plot
@@ -69,11 +70,11 @@ function(toPlot, oneGrp, data) {
     if(!is.null(data$y2))
       text( max(xVec) , maxY , bquote(N[2]==.(length(data$y2))) , adj=c(1.1,1.1) )
 
-    matlines(x=xVec, y=PPDmat[, , 2], lty=1, col="skyblue")
+    matlines(x=xVec, y=PPDmat[, , 2], lty=1, col=lineColor)
     if(!is.null(hist2)) {
       op <- par(lwd=2)
-      plot(hist2, freq=FALSE, border='red', add=TRUE)
-      segments(x0=xVec[1], y0=0, x1=xVec[npoints], col='red')
+      plot(hist2, freq=FALSE, border=dataColor, add=TRUE)
+      segments(x0=xVec[1], y0=0, x1=xVec[npoints], col=dataColor)
       par(op)
     }
   }

--- a/R/plotPost.R
+++ b/R/plotPost.R
@@ -2,13 +2,15 @@
 
 plotPost <-
 function( paramSampleVec, credMass=0.95, compVal=NULL, ROPE=NULL,
-           HDItextPlace=0.7, showMode=FALSE, showCurve=FALSE, ... ) {
+           HDItextPlace=0.7, showMode=FALSE, showCurve=FALSE, 
+           mainColor="skyblue", comparisonColor="darkgreen", ROPEColor = "darkred", 
+           ... ) {
 
   # Does a plot for a single parameter. Called by plot.BEST but also exported.
   # Returns a histogram object invisibly.
   # This stuff should be in the ... argument:
   #   yaxt="n", ylab="", xlab="Parameter", main="", cex.lab=1.5, cex=1.4,
-  #   xlim=range(compVal, paramSampleVec), col="skyblue", border="white",
+  #   xlim=range(compVal, paramSampleVec), col=mainColor, border="white",
   #   breaks=NULL
 
   # Deal with ... argument:
@@ -17,7 +19,7 @@ function( paramSampleVec, credMass=0.95, compVal=NULL, ROPE=NULL,
     dots <- dots[[1]]
   defaultArgs <- list(xlab=deparse(substitute(paramSampleVec)),
     yaxt="n", ylab="", main="", cex.lab=1.5,
-    cex=1.4, col="skyblue", border="white", bty="n", lwd=5, freq=FALSE,
+    cex=1.4, col=mainColor, border="white", bty="n", lwd=5, freq=FALSE,
     xlim=range(compVal, hdi(paramSampleVec, 0.99)))
   useArgs <- modifyList(defaultArgs, dots)
 
@@ -99,7 +101,7 @@ function( paramSampleVec, credMass=0.95, compVal=NULL, ROPE=NULL,
   # Display the comparison value.
   if ( !is.null( compVal ) ) {
     cvHt <- 0.7 * max(histinfo$density)
-    cvCol <- "darkgreen"
+    cvCol <- comparisonColor
     pcgtCompVal <- round( 100 * sum( paramSampleVec > compVal )
                           / length( paramSampleVec ) , 1 )
      pcltCompVal <- 100 - pcgtCompVal
@@ -113,7 +115,7 @@ function( paramSampleVec, credMass=0.95, compVal=NULL, ROPE=NULL,
   # Display the ROPE.
   if ( !is.null( ROPE ) ) {
     ROPEtextHt <- 0.55 * max(histinfo$density)
-    ropeCol <- "darkred"
+    ropeCol <- ROPEColor
      pcInROPE <- ( sum( paramSampleVec > ROPE[1] & paramSampleVec < ROPE[2] )
                           / length( paramSampleVec ) )
      lines( c(ROPE[1],ROPE[1]), c(0.96*ROPEtextHt,0), lty="dotted", lwd=2,

--- a/R/plotPostPred.R
+++ b/R/plotPostPred.R
@@ -1,7 +1,8 @@
 # Changed 11 Aug 2017 to show data as a typical histogram
 
 plotPostPred <-
-function(BESTobj, nCurvesToPlot = 30) {
+function(BESTobj, nCurvesToPlot = 30,
+         mainColor="skyblue", dataColor="red") {
   # This function plots the posterior predictive distribution and the data.
   # Description of arguments:
   # BESTobj is mcmc.list object of the type returned by function BESTmcmc.
@@ -32,6 +33,6 @@ function(BESTobj, nCurvesToPlot = 30) {
   stepIdxVec <- seq(1, NROW( BESTobj ), length= nCurvesToPlot)
   toPlot <- BESTobj[stepIdxVec, ]
 
-  plotDataPPC(toPlot=toPlot, oneGrp=oneGrp, data=data)
+  plotDataPPC(toPlot=toPlot, oneGrp=oneGrp, data=data, lineColor = mainColor , dataColor = dataColor)
 
 }

--- a/R/postPriorOverlap.R
+++ b/R/postPriorOverlap.R
@@ -1,8 +1,8 @@
-
 postPriorOverlap <-
 function( paramSampleVec, prior, ..., yaxt="n", ylab="",
            xlab="Parameter", main="", cex.lab=1.5, cex=1.4,
-           xlim=range(paramSampleVec), breaks=NULL) {
+           xlim=range(paramSampleVec), breaks=NULL,
+           mainColor="skyblue", priorColor="yellow", overlapColor="green") {
 
   # Does a posterior histogram for a single parameter, adds the prior,
   #   displays and calculates the overlap.
@@ -18,14 +18,14 @@ function( paramSampleVec, prior, ..., yaxt="n", ylab="",
   }
   # plot posterior histogram.
   histinfo <- hist(paramSampleVec, xlab=xlab, yaxt=yaxt, ylab=ylab,
-                   freq=FALSE, border='white', col='skyblue',
+                   freq=FALSE, border='white', col=mainColor,
                    xlim=xlim, main=main, cex=cex, cex.lab=cex.lab,
                    breaks=breaks)
 
   if (is.numeric(prior))  {
     # plot the prior if it's numeric
     priorInfo <- hist(prior, breaks=c(-Inf, breaks, Inf), add=TRUE,
-      freq=FALSE, col='yellow', border='white')$density[2:length(breaks)]
+      freq=FALSE, col=priorColor, border='white')$density[2:length(breaks)]
   } else if (is.function(prior)) {
     if(class(try(prior(0.5, ...), TRUE)) == "try-error")
       stop(paste("Incorrect arguments for the density function", substitute(prior)))
@@ -33,12 +33,12 @@ function( paramSampleVec, prior, ..., yaxt="n", ylab="",
   }
   # get (and plot) the overlap
   minHt <- pmin(priorInfo, histinfo$density)
-  rect(breaks[-length(breaks)], rep(0, length(breaks)-1), breaks[-1], minHt, col='green',
+  rect(breaks[-length(breaks)], rep(0, length(breaks)-1), breaks[-1], minHt, col=overlapColor,
     border='white')
   overlap <- sum(minHt * diff(histinfo$breaks))
   # Add curve if prior is a function
   if (is.function(prior))
-    lines(histinfo$mids, priorInfo, lwd=2, col='brown')
+    lines(histinfo$mids, priorInfo, lwd=2, col=priorColor)
   # Add text
   text(mean(breaks), 0, paste0("overlap = ", round(overlap*100), "%"), pos=3, cex=cex)
     

--- a/man/plot.BEST.Rd
+++ b/man/plot.BEST.Rd
@@ -8,7 +8,9 @@ Displays a plot showing the posterior probability distribution of one of the par
 }
 \usage{
 \method{plot}{BEST}(x, which = c("mean", "sd", "effect", "nu"), credMass = 0.95,
-    ROPE = NULL, compVal = 0, showCurve = FALSE, ...)
+    ROPE = NULL, compVal = 0, showCurve = FALSE, 
+    mainColor="skyblue", dataColor="red", comparisonColor="darkgreen", ROPEColor = "darkred",
+    ...)
 }
 \arguments{
   \item{x}{
@@ -29,6 +31,15 @@ logical: if TRUE, the posterior density will be represented by a kernel density 
   \item{compVal}{
 a value for comparison with the (difference of) parameters.
 }
+  \item{mainColor}{
+an optional color name such as \code{"skyblue"} or a RGB specification such as \code{"#87CEEB"} that controls the color of the bar charts and posterior prediction lines.
+}
+  \item{comparisonColor}{
+a optional color name such as \code{"darkgreen"} or a RGB specification such as \code{"#013220"} that controls the color of the text that specifies the relation of the HDI to a comparison value.
+}  
+  \item{ROPEColor}{
+a optional color name such as \code{"darkred"} or a RGB specification such as \code{"#8B0000"} that controls the color of the text that specifies the relation of the HDI to the ROPE.
+} 
   \item{...}{
 other graphical parameters.
 }

--- a/man/plotAll.Rd
+++ b/man/plotAll.Rd
@@ -10,7 +10,8 @@ Displays a series of plots showing the posterior probability distributions of th
 plotAll(BESTobj, credMass = 0.95,
   ROPEm = NULL, ROPEsd = NULL, ROPEeff = NULL,
   compValm = 0, compValsd = NULL, compValeff = 0,
-  showCurve = FALSE, ...)
+  showCurve = FALSE, 
+  mainColor="skyblue", dataColor="red", comparisonColor="darkgreen", ROPEColor = "darkred",...)
 }
 \arguments{
   \item{BESTobj}{
@@ -40,6 +41,18 @@ a value for comparison with the (difference of) standard deviations.
   \item{compValeff}{
 a value for comparison with the effect size.
 }
+  \item{mainColor}{
+an optional color name such as \code{"skyblue"} or a RGB specification such as \code{"#87CEEB"} that controls the color of the bar charts and posterior prediction lines.
+} 
+  \item{dataColor}{
+a optional color name such as \code{"red"} or a RGB specification such as \code{"#FF0000"} that controls the color of the data histogram.
+}  
+  \item{comparisonColor}{
+a optional color name such as \code{"darkgreen"} or a RGB specification such as \code{"#013220"} that controls the color of the text that specifies the relation of the HDI to a comparison value.
+}  
+  \item{ROPEColor}{
+a optional color name such as \code{"darkred"} or a RGB specification such as \code{"#8B0000"} that controls the color of the text that specifies the relation of the HDI to the ROPE.
+}  
   \item{...}{
 other graphical parameters (currently ignored).
 }

--- a/man/plotAll.Rd
+++ b/man/plotAll.Rd
@@ -45,13 +45,13 @@ a value for comparison with the effect size.
 an optional color name such as \code{"skyblue"} or a RGB specification such as \code{"#87CEEB"} that controls the color of the bar charts and posterior prediction lines.
 } 
   \item{dataColor}{
-a optional color name such as \code{"red"} or a RGB specification such as \code{"#FF0000"} that controls the color of the data histogram.
+an optional color name such as \code{"red"} or a RGB specification such as \code{"#FF0000"} that controls the color of the data histogram.
 }  
   \item{comparisonColor}{
-a optional color name such as \code{"darkgreen"} or a RGB specification such as \code{"#013220"} that controls the color of the text that specifies the relation of the HDI to a comparison value.
+an optional color name such as \code{"darkgreen"} or a RGB specification such as \code{"#013220"} that controls the color of the text that specifies the relation of the HDI to a comparison value.
 }  
   \item{ROPEColor}{
-a optional color name such as \code{"darkred"} or a RGB specification such as \code{"#8B0000"} that controls the color of the text that specifies the relation of the HDI to the ROPE.
+an optional color name such as \code{"darkred"} or a RGB specification such as \code{"#8B0000"} that controls the color of the text that specifies the relation of the HDI to the ROPE.
 }  
   \item{...}{
 other graphical parameters (currently ignored).

--- a/man/plotAreaInROPE.Rd
+++ b/man/plotAreaInROPE.Rd
@@ -10,7 +10,7 @@ Calculates and (optionally) plots the posterior probability mass included in the
 
 \usage{
 plotAreaInROPE(paramSampleVec, credMass = 0.95, compVal = 0, maxROPEradius,
-  n = 201, plot = TRUE, ...)
+  n = 201, plot = TRUE, ROPEColor = "darkred", ...)
 }
 
 \arguments{
@@ -31,6 +31,9 @@ The number of equally spaced points at which the area in the ROPE is to be estim
 }
   \item{plot}{
 If FALSE, the plot will be suppressed but the values will be returned.
+}
+  \item{ROPEColor}{
+an optional color name such as \code{"darkred"} or a RGB specification such as \code{"#8B0000"} that controls the color of the text that specifies the relation of the HDI to the ROPE.
 }
   \item{\dots}{
 Other graphical parameters.

--- a/man/plotPost.Rd
+++ b/man/plotPost.Rd
@@ -8,7 +8,9 @@ Plot the posterior probability distribution for a single parameter from a vector
 }
 \usage{
 plotPost(paramSampleVec, credMass = 0.95, compVal = NULL, ROPE = NULL,
-  HDItextPlace = 0.7, showMode = FALSE, showCurve = FALSE, ...)
+  HDItextPlace = 0.7, showMode = FALSE, showCurve = FALSE, 
+  mainColor="skyblue", comparisonColor="darkgreen", ROPEColor = "darkred",
+  ...)
 }
 \arguments{
   \item{paramSampleVec}{
@@ -31,6 +33,15 @@ logical: if TRUE, the mode is displayed instead of the mean.
 }
   \item{showCurve}{
 logical: if TRUE, the posterior density will be represented by a kernel density function instead of a histogram.
+}
+  \item{mainColor}{
+an optional color name such as \code{"skyblue"} or a RGB specification such as \code{"#87CEEB"} that controls the color of the bar charts and posterior prediction lines.
+} 
+  \item{comparisonColor}{
+a optional color name such as \code{"darkgreen"} or a RGB specification such as \code{"#013220"} that controls the color of the text that specifies the relation of the HDI to a comparison value.
+}  
+  \item{ROPEColor}{
+a optional color name such as \code{"darkred"} or a RGB specification such as \code{"#8B0000"} that controls the color of the text that specifies the relation of the HDI to the ROPE.
 }
   \item{\dots}{
 graphical parameters and the \code{breaks} parameter for the histogram.

--- a/man/plotPost.Rd
+++ b/man/plotPost.Rd
@@ -38,10 +38,10 @@ logical: if TRUE, the posterior density will be represented by a kernel density 
 an optional color name such as \code{"skyblue"} or a RGB specification such as \code{"#87CEEB"} that controls the color of the bar charts and posterior prediction lines.
 } 
   \item{comparisonColor}{
-a optional color name such as \code{"darkgreen"} or a RGB specification such as \code{"#013220"} that controls the color of the text that specifies the relation of the HDI to a comparison value.
+an optional color name such as \code{"darkgreen"} or a RGB specification such as \code{"#013220"} that controls the color of the text that specifies the relation of the HDI to a comparison value.
 }  
   \item{ROPEColor}{
-a optional color name such as \code{"darkred"} or a RGB specification such as \code{"#8B0000"} that controls the color of the text that specifies the relation of the HDI to the ROPE.
+an optional color name such as \code{"darkred"} or a RGB specification such as \code{"#8B0000"} that controls the color of the text that specifies the relation of the HDI to the ROPE.
 }
   \item{\dots}{
 graphical parameters and the \code{breaks} parameter for the histogram.

--- a/man/plotPostPred.Rd
+++ b/man/plotPostPred.Rd
@@ -20,7 +20,7 @@ the number of posterior predictive curves to plot.
 an optional color name such as \code{"skyblue"} or a RGB specification such as \code{"#87CEEB"} that controls the color of the posterior prediction lines.
 }
   \item{dataColor}{
-a optional color name such as \code{"red"} or a RGB specification such as \code{"#FF0000"} that controls the color of the data histogram.
+an optional color name such as \code{"red"} or a RGB specification such as \code{"#FF0000"} that controls the color of the data histogram.
 } 
 \value{
 Nothing, used for its side effect.

--- a/man/plotPostPred.Rd
+++ b/man/plotPostPred.Rd
@@ -7,7 +7,7 @@ Plots for Posterior Predictive checks.
 Plots a number (default 30) of credible t-distributions based on posterior values of the mean, standard deviation, and normality for each group, together with histograms of the data.   
 }
 \usage{
-plotPostPred(BESTobj, nCurvesToPlot = 30)
+plotPostPred(BESTobj, nCurvesToPlot = 30, mainColor="skyblue", dataColor="red"))
 }
 \arguments{
   \item{BESTobj}{
@@ -16,7 +16,12 @@ an object of class \code{BEST}, as produced by the function \code{\link{BESTmcmc
   \item{nCurvesToPlot}{
 the number of posterior predictive curves to plot.
 }
+  \item{mainColor}{
+an optional color name such as \code{"skyblue"} or a RGB specification such as \code{"#87CEEB"} that controls the color of the posterior prediction lines.
 }
+  \item{dataColor}{
+a optional color name such as \code{"red"} or a RGB specification such as \code{"#FF0000"} that controls the color of the data histogram.
+} 
 \value{
 Nothing, used for its side effect.
 }

--- a/man/postPriorOverlap.Rd
+++ b/man/postPriorOverlap.Rd
@@ -9,7 +9,8 @@ Calculates and displays the overlap between a posterior distribution (as a vecto
 \usage{
 postPriorOverlap(paramSampleVec, prior, ..., yaxt="n", ylab="",
            xlab="Parameter", main="", cex.lab=1.5, cex=1.4,
-           xlim=range(paramSampleVec), breaks=NULL)
+           xlim=range(paramSampleVec), breaks=NULL,
+           mainColor="skyblue", priorColor="yellow", overlapColor="green")
 }
 \arguments{
   \item{paramSampleVec}{
@@ -45,6 +46,15 @@ text to use as the main title of the plot
   \item{breaks}{
 controls the histogram break points or the number of bars; see \code{\link{hist}}.
 }
+  \item{mainColor}{
+an optional color name such as \code{"skyblue"} or a RGB specification such as \code{"#87CEEB"} that controls the color of the bar chart representing the posterior.
+}
+  \item{priorColor}{
+an optional color name such as \code{"yellow"} or a RGB specification such as \code{"#FFFF00"} that controls the color of prior, both if it is data and when it is a function.
+}
+  \item{overlapColor}{
+an optional color name such as \code{"green"} or a RGB specification such as \code{"#00FF00"} that controls the color of the overlap area.
+} 
 }
 \value{
 Returns the overlap, the area lying under the lower of the two density curves.


### PR DESCRIPTION
The plots all default to the colors used before and no existing code should be affected as the color variables are optional.
Added variables are:
```
mainColor="skyblue" 
dataColor="red"
comparisonColor="darkgreen"
ROPEColor = "darkred"
priorColor="yellow"
overlapColor="green"
```
The latter two are only used in postPriorOverlap.R.
Variables have been explained in the appropriate .Rd files.